### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 dist: trusty
+arch:
+  - amd64
+  - ppc64le
 sudo: false
 addons:
   apt:


### PR DESCRIPTION
This PR adds CI support for "Linux on Power architecture".  By doing CI for this, we can detect any issues earlier in the stage and fix them.