### PR TITLE
Fix two typos pointed out by codespell

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -200,7 +200,7 @@ screen-message (0.6-1) unstable; urgency=low
   * New upstream release:
     * Read from stdin if parameter is - (Closes: #429646)
     * Middle-Clicking anywhere works (Closes: #429648)
-    * End program upon destory (Closes: 428893)
+    * End program upon destroy (Closes: 428893)
     * Fix colors to black/white independent of the theme
 
  -- Joachim Breitner <nomeata@debian.org>  Tue, 19 Jun 2007 13:19:51 +0100

--- a/sm.c
+++ b/sm.c
@@ -125,7 +125,7 @@ static void redraw(GtkWidget *draw, cairo_t *cr, gpointer data) {
 				pango_layout_set_alignment(layout,PANGO_ALIGN_RIGHT);
 				break;
 			default:
-				// we propably don't want to annoy the user, so default to
+				// we probably don't want to annoy the user, so default to
 				// the old default-behaviour:
 				pango_layout_set_alignment(layout,PANGO_ALIGN_CENTER);
 		}


### PR DESCRIPTION
```console
# git ls-files | xargs codespell
debian/changelog:203: destory ==> destroy
sm.c:128: propably ==> probably
```

PS: If welcome, I can add CI based on GitHub Actions and [codespell](https://github.com/codespell-project/codespell) to prevent introduction of new typos through pull requests, in a new pull request. Would be similar to https://github.com/libexpat/libexpat/blob/master/.github/workflows/codespell.yml .