### PR TITLE
sm.6: Fix clock example for copy'n'paste

### DIFF
--- a/sm.6
+++ b/sm.6
@@ -96,7 +96,7 @@ once. Newline characters at the beginning or the end are ignored. The input is a
 .PP
 This can be used to create automatic displays of changing data or similar tricks. For example, the following command will create a simple digital watch:
 .sp
-.B (while sleep 1; do date +%T; printf '\\\\f'; done) | sm -
+.B (while sleep 1; do date +%T; printf \\\\\\\\f; done) | sm -
 
 
 .SH AUTHOR


### PR DESCRIPTION
Before (note the quotes, man-db 2.12.0):
```
(while sleep 1; do date +%T; printf ’\f’; done) | sm -
```

After:
```
(while sleep 1; do date +%T; printf \\f; done) | sm -
```